### PR TITLE
Fixed 'rails db:create'

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,7 +38,7 @@ module FatFreeCRM
     config.autoload_once_paths += [File.expand_path("../app/models/fields/field.rb", __FILE__)]
 
     # Activate observers that should always be running.
-    unless ARGV.join.include?('assets:precompile')
+    unless ARGV.join.include?('assets:precompile') || ARGV.join.include?('db:create')
       config.active_record.observers = :lead_observer, :opportunity_observer, :task_observer, :entity_observer
     end
 


### PR DESCRIPTION
- initialized `entities` models with `has_fields` has called
  `ActiveRecord :: Base.connection` when database doen't exists yet